### PR TITLE
Use `in-syntax` from `racket/sequence`.

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -43,7 +43,7 @@ with '-' prevents access.
                      racket/syntax
                      syntax/id-table
                      syntax/parse
-                     unstable/sequence
+                     racket/sequence
                      racket/format
                      syntax/strip-context)
          (for-meta 2 racket/base


### PR DESCRIPTION
Moved there as of v6.2.900.9.

This change is not compatible with Racket 6.2.1 and prior, which can be fixed by using version exceptions on pkgs.racket-lang.org.

This code will continue working (without this change) in subsequent Racket versions as long as the `unstable-lib` package is installed. This package will eventually not be part of the main distribution, and so would need an explicit dependency (which is a good idea in general). This solution in compatible with Racket 6.2.1 and prior.
